### PR TITLE
Add warning label when script that is loaded has been deleted by cvs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
-    "typescript": "^3.7.5",
+    "typescript": "4.8.3",
     "lzma": "2.3.2"
   },
   "scripts": {

--- a/src/components/AssetList.tsx
+++ b/src/components/AssetList.tsx
@@ -25,6 +25,7 @@ interface AssetListProps {
 interface AssetListState {
     items: AssetInfo[];
     runUrl?: string;
+    isDeleted?: boolean;
     selected: number;
     saving?: number;
     dragging?: boolean;
@@ -181,6 +182,8 @@ class AssetList extends React.Component<AssetListProps, AssetListState> {
         const scriptTarget = res?.meta?.target;
         const runUrl = scriptId && scriptTarget && `https://${res?.meta?.target}.makecode.com/---run?id=${res?.meta?.id}&noFooter=1&single=1&fullScreen=1`;
 
+        const cvsHatesThisScript = res.meta.isdeleted;
+
         if (replace) this._items = [];
         for (const el of res.projectImages) {
             if (!(await isStringApprovedAsync(el.previewURI))) {
@@ -240,7 +243,8 @@ class AssetList extends React.Component<AssetListProps, AssetListState> {
             items: this._items,
             textItems: unapprovedText,
             files,
-            runUrl
+            runUrl,
+            isDeleted: cvsHatesThisScript,
         });
     }
 
@@ -473,7 +477,7 @@ class AssetList extends React.Component<AssetListProps, AssetListState> {
     }
 
     render() {
-        const { items, selected, dragging, alert, textItems, files, runUrl } = this.state;
+        const { items, selected, dragging, alert, textItems, files, runUrl, isDeleted } = this.state;
 
         const { variableNames, assetNames, other } = textItems || {};
 
@@ -532,6 +536,11 @@ class AssetList extends React.Component<AssetListProps, AssetListState> {
                 </div>)}
             </div>
             }
+            {isDeleted && <div className="banned-script">
+                <h1>
+                    This script has been deleted by content moderation, and will not show up to users!
+                </h1>
+            </div>}
             {runUrl && <div className="sim-embed asset-files">
                 <iframe src={runUrl} sandbox="allow-popups allow-forms allow-scripts allow-same-origin"></iframe>
             </div>}

--- a/src/share.ts
+++ b/src/share.ts
@@ -80,6 +80,7 @@ export interface ScriptMeta {
         blocksWidth: number;
     };
     thumb: boolean;
+    isdeleted?: boolean;
 }
 
 export interface ScriptInfo {

--- a/src/styles/AssetList.css
+++ b/src/styles/AssetList.css
@@ -76,6 +76,18 @@
     padding: 0.5rem;
 }
 
+.banned-script {
+    display: flex;
+    justify-content: center;
+}
+.banned-script h1 {
+    background: #d23b3b;
+    border: solid 1px #821313;
+    border-radius: 2rem;
+    padding: 2rem;
+    display: inline-block;
+}
+
 .sim-embed {
     margin: 0 auto;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -27,7 +27,7 @@ export function browserDownloadDataUri(uri: string, name: string) {
         let byteString = atob(uri.split(',')[1]);
         let ia = stringToUint8Array(byteString);
         let blob = new Blob([ia], { type: "img/png" });
-        window.navigator.msSaveOrOpenBlob(blob, name);
+        (window.navigator as any).msSaveOrOpenBlob(blob, name);
     } else {
         let link = <any>window.document.createElement('a');
         if (typeof link.download == "string") {


### PR DESCRIPTION
here's an evil, crappy script to test with https://arcade.makecode.com/S62666-74059-97442-74897. for ref the script that was confusing was https://forum.makecode.com/t/the-ultimate-rpg/20021/6

![image](https://github.com/riknoll/mod-tool/assets/5615930/8cde81e1-5f4e-47b4-ae86-f524de1e8f16)

there was also a build error from a transitive dep in babel, so bumped ts to fix re: https://stackoverflow.com/questions/72717949/error-in-node-modules-types-babel-traverse-index-d-ts68-50-error-ts1005 (and new ts dropped the typing for `msSaveOrOpenBlob`, so anyfy that as well)