### PR TITLE
Grab strings from typescript and fix a couple bugs

### DIFF
--- a/src/components/AssetList.tsx
+++ b/src/components/AssetList.tsx
@@ -332,7 +332,14 @@ class AssetList extends React.Component<AssetListProps, AssetListState> {
         })
     }
 
+    protected lastEvent?: React.ClipboardEvent<HTMLInputElement>;
     onPaste = (ev: React.ClipboardEvent<HTMLInputElement>) => {
+        const data = ev.clipboardData.getData("text");
+        const lastData = this.lastEvent?.clipboardData.getData("text");
+        if (data === lastData) return;
+
+        this.lastEvent = ev;
+
         this.clearAssets();
         this.importAssets(ev.clipboardData.getData("text"));
         this.hideAlert();

--- a/src/styles/AssetList.css
+++ b/src/styles/AssetList.css
@@ -38,11 +38,11 @@
 .asset-file-content {
     background-color: #dedede;
     margin: 0 1rem 1rem 1rem;
+    overflow: scroll;
 }
 
 .asset-file-content.scroll {
     max-height: 500px;
-    overflow: scroll;
 }
 
 .asset-button {


### PR DESCRIPTION
Fixes two bugs:
1. strings sections now scroll instead of overflowing
2. the "onPaste" event was firing twice, causing images to be duplicated

Also adds some code to grab strings and comments from typescript files so they get displayed in the "strings" section.

things that still aren't extracted:
1. python (easy, I'm just lazy)
2. parameter names
3. function names
4. variable names