### PR TITLE
Aznhassan/pull out title

### DIFF
--- a/src/components/AssetList.tsx
+++ b/src/components/AssetList.tsx
@@ -36,6 +36,8 @@ interface AssetListState {
     textItems?: BlockFields;
     files?: FileInfo[];
     pngDialogOpen?: boolean;
+    projectName?: string;
+    projectDescription?: string;
 }
 
 const DEFAULT_NAME = "mySprite";
@@ -195,6 +197,8 @@ class AssetList extends React.Component<AssetListProps, AssetListState> {
         const runUrl = scriptId && scriptTarget && `https://${res?.meta?.target}.makecode.com/---run?id=${res?.meta?.id}&noFooter=1&single=1&fullScreen=1`;
 
         const cvsHatesThisScript = res?.meta?.isdeleted;
+        const projectName = res?.name;
+        const projectDescription = res?.description;
 
         if (replace) this._items = [];
         for (const el of res.projectImages) {
@@ -257,6 +261,8 @@ class AssetList extends React.Component<AssetListProps, AssetListState> {
             files,
             runUrl,
             isDeleted: cvsHatesThisScript,
+            projectName,
+            projectDescription,
         });
     }
 
@@ -492,7 +498,7 @@ class AssetList extends React.Component<AssetListProps, AssetListState> {
     }
 
     render() {
-        const { items, selected, dragging, alert, textItems, files, runUrl, isDeleted, pngDialogOpen } = this.state;
+        const { items, selected, dragging, alert, textItems, files, runUrl, isDeleted, pngDialogOpen, projectName, projectDescription } = this.state;
 
         const { variableNames, assetNames, other } = textItems || {};
 
@@ -543,6 +549,17 @@ class AssetList extends React.Component<AssetListProps, AssetListState> {
                 <div className="asset-filename">Strings</div>
                 <TextList text={other} />
             <button onClick={() => this.approveAllStringsAsync("other")}>Approve All Strings</button>
+            </div>
+            }
+            {!!(projectName || projectDescription) && <div className="asset-files">
+                    {!!projectName && <div className="asset-file">
+                        <div className="asset-filename">Title</div>
+                        <pre className="asset-file-content">{projectName}</pre>
+                    </div>}
+                    {!!projectDescription && <div className="asset-file">
+                        <div className="asset-filename">Description</div>
+                        <pre className="asset-file-content">{projectDescription}</pre>
+                    </div>}
             </div>
             }
             {!!files?.length && <div className="asset-files">

--- a/src/share.ts
+++ b/src/share.ts
@@ -103,6 +103,8 @@ export interface ImportedScriptInfo {
     text: BlockFields;
     customPalette?: string[];
     projectImages: JRESImage[];
+    name?: string;
+    description?: string;
 }
 
 
@@ -120,7 +122,7 @@ export async function fetchMakeCodeScriptAsync(url: string): Promise<ImportedScr
     // A mapping of filenames to filecontents
     const filesystem: {[index: string]: string} = await httpGetJSONAsync(backendEndpoint + "/" + scriptID + "/text");
 
-    const { palette, paletteIsCustom } = resolvePalette(filesystem);
+    const { palette, paletteIsCustom, name, description } = resolvePalette(filesystem);
     const projectImages = grabImagesFromProject(filesystem, palette);
 
     return {
@@ -128,14 +130,18 @@ export async function fetchMakeCodeScriptAsync(url: string): Promise<ImportedScr
         files: filesystem,
         projectImages: projectImages,
         text: grabTextFromProject(filesystem),
-        customPalette: paletteIsCustom ? palette : undefined
+        customPalette: paletteIsCustom ? palette : undefined,
+        name,
+        description
     };
 }
 
-function resolvePalette(filesystem: {[index: string]: string}): { palette: string[], paletteIsCustom: boolean } {
+function resolvePalette(filesystem: {[index: string]: string}): { palette: string[], paletteIsCustom: boolean, name?: string, description?: string } {
     const config = filesystem["pxt.json"];
     let palette = arcadePalette;
     let paletteIsCustom = false;
+    let name: string | undefined;
+    let description: string | undefined;
 
     if (config) {
         try {
@@ -144,24 +150,34 @@ function resolvePalette(filesystem: {[index: string]: string}): { palette: strin
                 palette = parsedConfig.palette.slice();
                 paletteIsCustom = true;
             }
+
+            if (typeof parsedConfig?.name === "string" && parsedConfig.name.trim()) {
+                name = parsedConfig.name.trim();
+            }
+
+            if (typeof parsedConfig?.description === "string" && parsedConfig.description.trim()) {
+                description = parsedConfig.description.trim();
+            }
         }
         catch (e) {
             // ignore
         }
     }
 
-    return { palette, paletteIsCustom };
+    return { palette, paletteIsCustom, name, description };
 }
 
 export async function parseProject(filesystem: {[index: string]: string}): Promise<ImportedScriptInfo> {
-    const { palette, paletteIsCustom } = resolvePalette(filesystem);
+    const { palette, paletteIsCustom, name, description } = resolvePalette(filesystem);
     const projectImages = grabImagesFromProject(filesystem, palette);
 
     return {
         files: filesystem,
         projectImages: projectImages,
         text: grabTextFromProject(filesystem),
-        customPalette: paletteIsCustom ? palette : undefined
+        customPalette: paletteIsCustom ? palette : undefined,
+        name,
+        description
     };
 }
 

--- a/src/share.ts
+++ b/src/share.ts
@@ -120,25 +120,7 @@ export async function fetchMakeCodeScriptAsync(url: string): Promise<ImportedScr
     // A mapping of filenames to filecontents
     const filesystem: {[index: string]: string} = await httpGetJSONAsync(backendEndpoint + "/" + scriptID + "/text");
 
-    const config = filesystem["pxt.json"];
-
-    let palette = arcadePalette;
-    let paletteIsCustom = false;
-
-    if (config) {
-        try {
-            let parsedConfig = JSON.parse(config);
-
-            if (parsedConfig?.palette && Array.isArray(parsedConfig.palette)) {
-                palette = parsedConfig.palette.slice()
-                paletteIsCustom = true;
-            }
-        }
-        catch (e) {
-            // ignore
-        }
-    }
-
+    const { palette, paletteIsCustom } = resolvePalette(filesystem);
     const projectImages = grabImagesFromProject(filesystem, palette);
 
     return {
@@ -150,18 +132,16 @@ export async function fetchMakeCodeScriptAsync(url: string): Promise<ImportedScr
     };
 }
 
-export async function parseProject(filesystem: {[index: string]: string}): Promise<ImportedScriptInfo> {
+function resolvePalette(filesystem: {[index: string]: string}): { palette: string[], paletteIsCustom: boolean } {
     const config = filesystem["pxt.json"];
-
     let palette = arcadePalette;
     let paletteIsCustom = false;
 
     if (config) {
         try {
-            let parsedConfig = JSON.parse(config);
-
+            const parsedConfig = JSON.parse(config);
             if (parsedConfig?.palette && Array.isArray(parsedConfig.palette)) {
-                palette = parsedConfig.palette.slice()
+                palette = parsedConfig.palette.slice();
                 paletteIsCustom = true;
             }
         }
@@ -170,6 +150,11 @@ export async function parseProject(filesystem: {[index: string]: string}): Promi
         }
     }
 
+    return { palette, paletteIsCustom };
+}
+
+export async function parseProject(filesystem: {[index: string]: string}): Promise<ImportedScriptInfo> {
+    const { palette, paletteIsCustom } = resolvePalette(filesystem);
     const projectImages = grabImagesFromProject(filesystem, palette);
 
     return {


### PR DESCRIPTION
### Problem
When using the mod tool to exam why a project has been removed, the `name` and `description` fields can be the culprits. In my case, a user typed a curse word into their description, and I didn't notice it until another pointed it out to me. 

### Solution
Make the `name` and `description` fields more visible by pulling them out of the `pxt.json` from each project and adding them to their own sections. More than happy if you'd rather they be in a combined section.

### Validation:
<img width="722" height="727" alt="image" src="https://github.com/user-attachments/assets/32222c3b-342e-45b6-9b53-fbedad8bc8a5" />

### Notes
I also did some minor refactoring since we were grabbing the palette's the same way from `pxt.json` in two functions.